### PR TITLE
Build for OBS 30.2

### DIFF
--- a/com.obsproject.Studio.Plugin.waveform.yml
+++ b/com.obsproject.Studio.Plugin.waveform.yml
@@ -2,7 +2,7 @@ id: com.obsproject.Studio.Plugin.waveform
 branch: stable
 runtime: com.obsproject.Studio
 runtime-version: stable
-sdk: org.kde.Sdk//6.5
+sdk: org.kde.Sdk//6.6
 build-extension: true
 separate-locales: false
 appstream-compose: false
@@ -29,6 +29,8 @@ modules:
           tag-query: .tag_name
           version-query: $tag | sub("^v"; "")
           timestamp-query: .published_at
+      - type: patch
+        path: ignore-symbol-check.patch
 
     modules:
       - shared-modules/linux-audio/fftw3f.json

--- a/ignore-symbol-check.patch
+++ b/ignore-symbol-check.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 447871b..55ed691 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -225,7 +225,7 @@ if(APPLE)
+ endif()
+
+ set(CMAKE_REQUIRED_LIBRARIES OBS::libobs)
+-check_symbol_exists(obs_properties_add_color_alpha "obs-module.h" HAVE_OBS_PROP_ALPHA)
++set(HAVE_OBS_PROP_ALPHA, ON)
+ configure_file("src/waveform_config.hpp.in" "include/waveform_config.hpp")
+ if(WIN32)
+     configure_file("installer/installer.iss.in" "${CMAKE_CURRENT_SOURCE_DIR}/installer/installer.iss" @ONLY)


### PR DESCRIPTION
@phandasm The latest version of OBS broke plugins, so a rebuild is needed. However building Waveform fails with this error:

```
-- Looking for obs_properties_add_color_alpha
CMake Error in /run/build/waveform/CMakeFiles/CMakeScratch/TryCompile-qP7bFG/CMakeLists.txt:
  No known features for CXX compiler

  ""

  version .


CMake Error at /usr/share/cmake-3.29/Modules/CheckSymbolExists.cmake:140 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  /usr/share/cmake-3.29/Modules/CheckSymbolExists.cmake:66 (__CHECK_SYMBOL_EXISTS_IMPL)
  CMakeLists.txt:228 (check_symbol_exists)
```

I added a patch to bypass the check for `obs_properties_add_color_alpha` to make Waveform work again as soon as possible. Is it okay for you to merge as is or do you want to investigate for a fix?